### PR TITLE
Added citation metadata for 1.0.2 release as CFF file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+# YAML 1.2
+# Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
+--- 
+authors: 
+  - 
+    affiliation: "Netherlands eScience Center"
+    family-names: Weel
+    given-names: Berend
+  - 
+    affiliation: "Netherlands eScience Center"
+    family-names: Spaaks
+    given-names: Jurriaan H.
+cff-version: "1.0.3"
+commit: 36f241eec127e6f58c9304680d9c3e53fd703550
+date-released: 2018-01-16
+doi: 10.5281/zenodo.1149011
+keywords: 
+  - "docker"
+  - "docker-compose"
+  - "containers"
+license: Apache-2.0
+message: "If you use this software, please cite it using these metadata."
+repository-code: "https://github.com/NLeSC/boatswain"
+title: boatswain
+version: "1.0.2"


### PR DESCRIPTION
we're fiddling with citation files in CFF format (here; https://github.com/citationcff/citationcff) in an attempt to fill the RSD site (here: https://github.com/research-software-directory) with metadata from the github repos